### PR TITLE
Expire refresh token

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -122,11 +122,15 @@ class TokenEndpoint(object):
             try:
                 self.token = Token.objects.get(refresh_token=self.params['refresh_token'],
                                                client=self.client)
-
             except Token.DoesNotExist:
                 logger.debug(
                     '[Token] Refresh token does not exist: %s', self.params['refresh_token'])
                 raise TokenError('invalid_grant')
+
+            if self.token.has_expired_refresh_token():
+                logger.debug(
+                    '[Token] Refresh token expired: %s', self.params['refresh_token'])
+                raise TokenError('invalid_token')
         elif self.params['grant_type'] == 'client_credentials':
             if not self.client._scope:
                 logger.debug('[Token] Client using client credentials with empty scope')

--- a/oidc_provider/lib/utils/oauth2.py
+++ b/oidc_provider/lib/utils/oauth2.py
@@ -7,7 +7,6 @@ from django.http import HttpResponse
 from oidc_provider.lib.errors import BearerTokenError
 from oidc_provider.models import Token
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -21,7 +20,7 @@ def extract_access_token(request):
     """
     auth_header = request.META.get('HTTP_AUTHORIZATION', '')
 
-    if re.compile('^[Bb]earer\s{1}.+$').match(auth_header):
+    if re.compile(r'^[Bb]earer\s{1}.+$').match(auth_header):
         access_token = auth_header.split()[1]
     else:
         access_token = request.GET.get('access_token', '')
@@ -39,7 +38,7 @@ def extract_client_auth(request):
     """
     auth_header = request.META.get('HTTP_AUTHORIZATION', '')
 
-    if re.compile('^Basic\s{1}.+$').match(auth_header):
+    if re.compile(r'^Basic\s{1}.+$').match(auth_header):
         b64_user_pass = auth_header.split()[1]
         try:
             user_pass = b64decode(b64_user_pass).decode('utf-8').split(':')
@@ -63,7 +62,7 @@ def protected_resource_view(scopes=None):
         scopes = []
 
     def wrapper(view):
-        def view_wrapper(request,  *args, **kwargs):
+        def view_wrapper(request, *args, **kwargs):
             access_token = extract_access_token(request)
 
             try:
@@ -86,7 +85,7 @@ def protected_resource_view(scopes=None):
                     error.code, error.description)
                 return response
 
-            return view(request,  *args, **kwargs)
+            return view(request, *args, **kwargs)
 
         return view_wrapper
 

--- a/oidc_provider/settings.py
+++ b/oidc_provider/settings.py
@@ -114,6 +114,19 @@ class DefaultSettings(object):
         return 60*60
 
     @property
+    def OIDC_REFRESH_TOKEN_EXPIRE(self):
+        """
+        OPTIONAL. Refresh token expiration time expressed in seconds.
+
+        Zero: Refresh token doesn't expire.
+        Note: Increasing expiration time settings could make previously
+        expired refresh tokens usable. Hence, increase expiry time with care.
+        Ex: delete existing refresh tokens before increasing
+        refresh token expire time.
+        """
+        return 0
+
+    @property
     def OIDC_USERINFO(self):
         """
         OPTIONAL. A string with the location of your function.


### PR DESCRIPTION
- Refresh token expires according to the OIDC_REFRESH_TOKEN_EXPIRE setting.
